### PR TITLE
feat: add Desmos bin and home path to the action outputs

### DIFF
--- a/.github/workflows/test_start.yaml
+++ b/.github/workflows/test_start.yaml
@@ -14,9 +14,17 @@ jobs:
 
       - name: Start chain
         uses: ./action
+        id: start-chain
         with:
           version: v4.4.1
 
       - name: Test chain started
         run: "[[ \"$(./desmos q block | jq '.block')\" != \"null\" ]]"
         shell: bash
+
+      - name: Check outputs
+        run: '[[ ! -z "$DESMOS_BIN" ]] && [[ ! -z "$DESMOS_HOME" ]]'
+        shell: bash
+        env:
+          DESMOS_BIN: ${{ steps.start-chain.outputs.desmos-bin }}
+          DESMOS_HOME: ${{ steps.start-chain.outputs.desmos-home }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub action to spawn a Desmos chain
 
 * [Example workflow](#example-workflow)
 * [Inputs](#inputs)
-
+* [Outputs](#outputs)
 
 ## Example workflow
 
@@ -40,3 +40,11 @@ jobs:
 | `genesis-file` |          | Path to the genesis file that should be used to start the chain | string | ""      |
 | `pre-run`      |          | Script to be executed before the chain starts                   | string | ""      |
 | `post-run`     |          | Script to be executed after the chain has started               | string | ""      |
+
+
+## Outputs
+
+| Name         | Description        |
+|--------------|--------------------|
+| `desmo-bin`  | Desmos binary path |
+| `desmo-home` | Desmos home path   |

--- a/action.yaml
+++ b/action.yaml
@@ -20,11 +20,20 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  desmos-bin:
+    description: "Desmos binary path"
+    value: ${{ steps.start-chain.outputs.desmos-bin }}
+  desmos-home:
+    description: "Desmos home path"
+    value: ${{ steps.start-chain.outputs.desmos-home }}
+
 runs:
   using: "composite"
   steps:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
 
-    - run: start-chain.sh ${{ inputs.version }} ${{ inputs.genesis-file }} ${{ inputs.pre-run }} ${{ inputs.post-run }}
+    - id: start-chain
+      run: CI=true start-chain.sh ${{ inputs.version }} ${{ inputs.genesis-file }} ${{ inputs.pre-run }} ${{ inputs.post-run }} >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
This PR adds the following outputs to the action:
* `desmos-bin`: path to the desmos binary;
* `desmos-home`: path of the desmos home directory. 

With this outputs a developer can know the paths to interact with the started chain.