### PR TITLE
fix: use chain id from the provided genesis file

### DIFF
--- a/start-chain.sh
+++ b/start-chain.sh
@@ -53,8 +53,15 @@ prepare_chain() {
 
   log "Using genesis file: $user_genesis_file"
 
-  $DESMOS_BIN testnet --v 1 --keyring-backend=test \
-    --gentx-coin-denom="stake" --minimum-gas-prices="0.000006stake" > /dev/null 2>&1
+  if test -f "$user_genesis_file"; then
+    # Get chain id from genesis file
+    user_chain_id=$(jq -r '.chain_id' "$user_genesis_file")
+    $DESMOS_BIN testnet --v 1 --keyring-backend=test --chain-id="$user_chain_id" \
+        --gentx-coin-denom="stake" --minimum-gas-prices="0.000006stake" > /dev/null 2>&1
+  else
+    $DESMOS_BIN testnet --v 1 --keyring-backend=test \
+            --gentx-coin-denom="stake" --minimum-gas-prices="0.000006stake" > /dev/null 2>&1
+  fi
 
   # Generated genesis file path
   node_genesis_file_path="$DESMOS_HOME/config/genesis.json"


### PR DESCRIPTION
This PR fixes a bug that cause the chain to start with a random chainid instead of the one provided in the user genesis file